### PR TITLE
fix RPOC grant password double URI encoding

### DIFF
--- a/RingCentral/platform/Platform.cs
+++ b/RingCentral/platform/Platform.cs
@@ -59,7 +59,7 @@ namespace RingCentral.SDK
             var body = new Dictionary<string, string>
                        {
                            {"username", userName},
-                           {"password", Uri.EscapeUriString(password)},
+                           {"password", password},
                            {"extension", extension},
                            {"grant_type", "password"},
                            {"access_token_ttl", AccessTokenTtl},

--- a/ringcentral.mac.nuspec
+++ b/ringcentral.mac.nuspec
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>RingCentralSDK</id>
+    <version>0.1.1</version>
+    <title>RingCentral SDK</title>
+    <authors>Paul Zolnierczyk</authors>
+    <owners>RingCentral</owners>
+    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+    <projectUrl>https://github.com/ringcentral/ringcentral-csharp</projectUrl>
+    <!-- <iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl> -->
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>RingCentral C# SDK</description>
+    <copyright>Copyright 2015</copyright>
+    <tags>RingCentral Ring Central C# SDK</tags>
+    <dependencies>  
+    
+      <group targetFramework="net40">
+        <dependency id="Microsoft.Bcl" version="1.1.10"  />
+        <dependency id="Microsoft.Bcl.Build" version="1.0.14"  />
+        <dependency id="Microsoft.Net.Http" version="2.2.29"  />
+        <dependency id="Newtonsoft.Json" version="7.0.1" /> 
+      </group>
+      
+      <group targetFramework="portable-net40">
+        <dependency id="Microsoft.Bcl" version="1.1.10"  />
+        <dependency id="Microsoft.Bcl.Build" version="1.0.14"  />
+        <dependency id="Microsoft.Net.Http" version="2.2.29"  />
+        <dependency id="Newtonsoft.Json" version="7.0.1" /> 
+      </group>
+      
+      <group targetFramework="portable-net45+sl5+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1">
+        <dependency id="Newtonsoft.Json" version="7.0.1" /> 
+      </group>
+      
+    </dependencies>
+  </metadata>          
+  <files>
+
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/portable-net45+sl5+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1" />
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/portable-net40" />            
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/net40" />
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/net45" />
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/sl5" />
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/MonoTouch1" />
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/MonoAndroid1" />
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/MonoMac" />
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/Xamarin.Mac" />
+    <file src="RingCentral/bin/Release/RingCentral.dll" target="lib/Xamarin.iOS" />
+    <file src="RingCentral.NET40/bin/Release/RingCentral.NET40.dll" target="lib/portable-net45+sl5+netcore45+wpa81+wp8" />
+    <file src="RingCentral.NET40/bin/Release/RingCentral.NET40.dll" target="lib/portable-net40" />
+    <file src="RingCentral.NET40/bin/Release/RingCentral.NET40.dll" target="lib/net40" />
+    <file src="RingCentral.NET40/bin/Release/RingCentral.NET40.dll" target="lib/net45" />
+    <file src="RingCentral.NET40/bin/Release/RingCentral.NET40.dll" target="lib/sl5" />
+    <file src="RingCentral.iOS/bin/iPhone/Release/RingCentral.iOS.dll" target="lib\MonoTouch1" />
+    <file src="RingCentral.iOS/bin/iPhone/Release/RingCentral.iOS.dll" target="lib\MonoMac" />
+    <file src="RingCentral.iOS/bin/iPhone/Release/RingCentral.iOS.dll" target="lib\Xamarin.Mac" />
+    <file src="RingCentral.iOS/bin/iPhone/Release/RingCentral.iOS.dll" target="lib\Xamarin.iOS" />
+    <file src="RingCentral.Android/bin/Release/RingCentral.Android.dll" target="lib\MonoAndroid1" />
+
+  </files>
+</package>


### PR DESCRIPTION
1. Fix double encoding of OAuth RPOC grant password
2. Add mac formatted `ringcentral.nuspec`