### PR TITLE
Download count API discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # RingCentral SDK for C&#35;
 
 [![NuGet][nuget-version-svg]][nuget-version-link]
-[![NuGet][nuget-count-svg]][nuget-count-link]
 [![Build Status][build-status-svg]][build-status-link]
 [![Coverage Status][coverage-status-svg]][coverage-status-link]
 [![Docs][docs-readthedocs-svg]][docs-readthedocs-link]


### PR DESCRIPTION
Remove download count shield because V3 API no longer supports download count:

* https://github.com/NuGet/Home/issues/2596