### PR TITLE
Issue where Auth would incorrectly state that access_token is not valid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,8 @@ _TeamCity*
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml
+*ncrunchsolution*
+*ncrunchproject*
 
 # MightyMoose
 *.mm.*

--- a/RingCentral.Test.Mock/AuthenticationTests.cs
+++ b/RingCentral.Test.Mock/AuthenticationTests.cs
@@ -148,6 +148,32 @@ namespace RingCentral.Test
         }
 
         [Test]
+        public void ShouldReturnAccessTokenValidGivenRestoredAuthData()
+        {
+            // Given
+            var accessTokenExpireIn = DateTime.UtcNow.AddHours(1).Ticks/TimeSpan.TicksPerMillisecond;
+            var refreshTokenExpireIn = DateTime.UtcNow.AddDays(7).Ticks / TimeSpan.TicksPerMillisecond;
+            var data = new Dictionary<string, string>()
+            {
+                {"access_token", "ac1"},
+                {"expires_in", "3598"},
+                {"expire_time", accessTokenExpireIn.ToString()},
+                {"refresh_token", "x"},
+                {"refresh_token_expires_in", "604798"},
+                {"refresh_token_expire_time", refreshTokenExpireIn.ToString()},
+            };
+
+            // When
+            var auth = new Auth();
+            auth.SetData(data);
+
+            // Then expire_time should be set and token still valid
+            var newData = auth.GetData();
+            Assert.That(newData["expire_time"], Is.EqualTo(data["expire_time"]));
+            Assert.That(auth.IsAccessTokenValid(), Is.EqualTo(true));
+        }
+
+        [Test]
         public void GenerateAuthorizeUri()
         {
             var authorizeUri = sdk.Platform.AuthorizeUri("http://localhost:3000", "myState");

--- a/RingCentral.Test.Mock/AuthenticationTests.cs
+++ b/RingCentral.Test.Mock/AuthenticationTests.cs
@@ -62,10 +62,10 @@ namespace RingCentral.Test
         [Test]
         public void TestAuthentication()
         {
-            var AuthResult = sdk.Platform.Login("username", "101", "password", true);
-            Assert.NotNull(AuthResult);
+            var authResult = sdk.Platform.Login("username", "101", "password", true);
+            Assert.NotNull(authResult);
 
-            JToken token = JObject.Parse(AuthResult.Body);
+            JToken token = JObject.Parse(authResult.Body);
             var accessToken = (string)token.SelectToken("access_token");
             var refreshToken = (string)token.SelectToken("refresh_token");
 
@@ -77,7 +77,7 @@ namespace RingCentral.Test
         public void TestRefresh()
         {
 
-            ApiResponse refreshResult = sdk.Platform.Refresh();
+            var refreshResult = sdk.Platform.Refresh();
 
             Assert.NotNull(refreshResult);
 
@@ -93,8 +93,8 @@ namespace RingCentral.Test
         [Test]
         public void TestVersion()
         {
-            Request request = new Request(VersionEndPoint);
-            ApiResponse response = sdk.Platform.Get(request);
+            var request = new Request(VersionEndPoint);
+            var response = sdk.Platform.Get(request);
 
             JToken token = response.Json;
             var version = (string)token.SelectToken("apiVersions").First().SelectToken("uriString");
@@ -112,10 +112,10 @@ namespace RingCentral.Test
         [Test]
         public void GetAuthData()
         {
-            var AuthResult = sdk.Platform.Login("username", "101", "password", true);
+            var authResult = sdk.Platform.Login("username", "101", "password", true);
             var authData = sdk.Platform.Auth.GetData();
 
-            JToken token = AuthResult.Json;
+            JToken token = authResult.Json;
 
             Assert.AreEqual((string)token.SelectToken("access_token"), authData["access_token"]);
             Assert.AreEqual((string)token.SelectToken("refresh_token"), authData["refresh_token"]);
@@ -127,15 +127,17 @@ namespace RingCentral.Test
             sdk.Platform.Login("username", "101", "password", true);
             var oldAuthData = sdk.Platform.Auth.GetData();
 
-            var newAuthData = new Dictionary<string, string>();
-            newAuthData.Add("remember", "true");
-            newAuthData.Add("token_type", "test");
-            newAuthData.Add("owner_id", "test");
-            newAuthData.Add("scope", "test");
-            newAuthData.Add("access_token", oldAuthData["access_token"]);
-            newAuthData.Add("expires_in", oldAuthData["expires_in"]);
-            newAuthData.Add("refresh_token", oldAuthData["refresh_token"]);
-            newAuthData.Add("refresh_token_expires_in", oldAuthData["refresh_token_expires_in"]);
+            var newAuthData = new Dictionary<string, string>
+            {
+                {"remember", "true"},
+                {"token_type", "test"},
+                {"owner_id", "test"},
+                {"scope", "test"},
+                {"access_token", oldAuthData["access_token"]},
+                {"expires_in", oldAuthData["expires_in"]},
+                {"refresh_token", oldAuthData["refresh_token"]},
+                {"refresh_token_expires_in", oldAuthData["refresh_token_expires_in"]}
+            };
 
             sdk.Platform.Auth.SetData(newAuthData);
 

--- a/RingCentral/Platform/Auth.cs
+++ b/RingCentral/Platform/Auth.cs
@@ -53,7 +53,7 @@ namespace RingCentral
                 scope = (string)jToken.SelectToken("scope");
             }
             #endregion
-            var currentTimeInMilliseconds = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+            var currentTimeInMilliseconds = DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
 
             #region Access Token
             if (!string.IsNullOrEmpty((string)jToken.SelectToken("access_token")))
@@ -124,7 +124,7 @@ namespace RingCentral
                 scope = data["scope"];
             }
             #endregion
-            var currentTimeInMilliseconds = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+            var currentTimeInMilliseconds = DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
 
             #region Access Token
             if (data.ContainsKey("access_token") && !String.IsNullOrEmpty(data["access_token"]))
@@ -142,7 +142,7 @@ namespace RingCentral
             {
                 accessTokenExpireTime = ((Convert.ToInt64(data["expires_in"]) * 1000) + currentTimeInMilliseconds);
             }
-            else if (data.ContainsKey("expires_time") && !string.IsNullOrEmpty(data["expire_time"]))
+            else if (data.ContainsKey("expire_time") && !string.IsNullOrEmpty(data["expire_time"]))
             {
                 accessTokenExpireTime = Convert.ToInt64(data["expire_time"]);
             }
@@ -221,7 +221,7 @@ namespace RingCentral
         /// <returns>bool value of token validity</returns>
         private bool IsTokenValid(long tokenExpireTime)
         {
-            var currentTimeInMilliseconds = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+            var currentTimeInMilliseconds = DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
             return tokenExpireTime > currentTimeInMilliseconds;
         }
 


### PR DESCRIPTION
`Auth` class incorrectly did not restore `expire_time`. This meant that `IsAccessTokenValid` would incorrectly return `false` when in fact token is still valid.

Further considerations:
* Test name could be different, e.g. `TestAuthRestore` to follow existing standard. 
* `Auth.cs` should just use `consts` instead of duplicating strings everywhere. Left this out of scope.
* Updated `IsTokenValid` to use `UTC` time instead of local. This would cause issues during DST switch.
* Ignored `NCrunch` files - this is something I use constantly and would get in the way.


Before applying the fix, the `expire_time` value in the restored data was '0'. 
`````
  Expected string length 14 but was 1. Strings differ at index 0.
  Expected: "63600505641136"
  But was:  "0"
  -----------^

   at NUnit.Framework.Assert.That(Object actual, IResolveConstraint expression, String message, Object[] args)
   at NUnit.Framework.Assert.That(Object actual, IResolveConstraint expression)
   at RingCentral.Test.AuthenticationTests.ShouldReturnAccessTokenValidGivenRestoredAuthData() in C:\work\projects\ringcentral-csharp\RingCentral.Test.Mock\AuthenticationTests.cs:line 185
`````